### PR TITLE
Fix Node server formatting issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 let express = require('express');
 let app = express();
-let ejs = require('ejs');
 const haikus = require('./haikus.json');
 const port = process.env.PORT || 3000;
 
-app.use(express.static('public'))
+app.use(express.static('public'));
 app.set('view engine', 'ejs');
 
 app.get('/', (req, res) => {


### PR DESCRIPTION
## Summary
- remove unused `ejs` require
- terminate static-middleware call with a semicolon
- ensure trailing newline after server listen statement

## Testing
- `npm test` *(fails: Missing script)*
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684498f55fbc8330b54012fd5b43863a