### PR TITLE
Fix mobile CSS selector to use mona-images

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -25,7 +25,7 @@ body {
 }
 
 @media only screen and (max-width: 600px) {
-    .june-images {
+    .mona-images {
         max-width: 340px;
         max-height: 340px;
     }


### PR DESCRIPTION
### Motivation
- The mobile media-query used the old `.june-images` selector while the template uses `mona-images`, causing inconsistent mobile styling; this change unifies the class name so styles apply correctly.

### Description
- Replaced `.june-images` with `.mona-images` inside the `@media only screen and (max-width: 600px)` block in `public/css/main.css`.
- Verified `views/index.ejs` already uses `class="mona-images"`, so markup and CSS are now consistent.
- Searched the codebase for remaining `june` occurrences related to image class naming and confirmed there are no other remnants.

### Testing
- Ran `rg -n "june|mona-images"` to confirm the replacement and ensure no remaining `june` selectors, which succeeded.
- Started the app with `node index.js` to serve the site and confirmed the server started successfully.
- Executed a Playwright script to capture screenshots at `1280x900` (desktop) and `390x844` (mobile) and verified image sizing behaves as expected in both viewports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699355ab375c833095b6e4a44476b9bf)